### PR TITLE
Feature add content components

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "builder": "^2.9.1",
     "builder-docs-archetype": "^3.0.2",
     "chai": "^3.2.0",
+    "component-playground": "FormidableLabs/component-playground",
     "ecology": "^1.6.0",
     "formidable-landers": "^3.3.3",
     "history": "~1.17.0",
@@ -43,6 +44,6 @@
     "react-router-scroll": "^0.2.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "component-playground": "FormidableLabs/component-playground"
+    "victory": "^0.10.4"
   }
 }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,18 +1,18 @@
 /* global window */
 import React from "react";
-import Radium, { Style, StyleRoot } from "radium";
+import Radium, { StyleRoot } from "radium";
 
 // Variables and Stylesheet
-import { Header } from "formidable-landers";
+import { Header, Footer } from "formidable-landers";
 
 class App extends React.Component {
   render() {
     const isBrowser = typeof window !== "undefined" && window.__STATIC_GENERATOR !== true;
     return (
       <StyleRoot radiumConfig={isBrowser ? { userAgent: window.navigator.userAgent } : null}>
-        <Header>
-        </Header>
+        <Header/>
         {this.props.children}
+        <Footer/>
       </StyleRoot>
     );
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,11 +5,13 @@ import Home from "./screens/home/index";
 // Components
 import App from "./components/app";
 import { Guide, Docs } from "./screens/docs/index";
+import About from "./screens/about/index";
 
 module.exports = (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
     <Route path="/docs" component={Docs}/>
     <Route path="/docs/getting-started" component={Guide}/>
+    <Route path="/about" component={About}/>
   </Route>
 );

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,14 +1,15 @@
 import React from "react";
 import { Route, IndexRoute } from "react-router";
 import Home from "./screens/home/index";
-import Guide from "./screens/docs/index";
 
 // Components
 import App from "./components/app";
+import { Guide, Docs } from "./screens/docs/index";
 
 module.exports = (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
+    <Route path="/docs" component={Docs}/>
     <Route path="/docs/getting-started" component={Guide}/>
   </Route>
 );

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Route, IndexRoute } from "react-router";
 import Home from "./screens/home/index";
+import Guide from "./screens/docs/index";
 
 // Components
 import App from "./components/app";
@@ -8,5 +9,6 @@ import App from "./components/app";
 module.exports = (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
+    <Route path="/docs/getting-started" component={Guide}/>
   </Route>
 );

--- a/src/screens/about/index.js
+++ b/src/screens/about/index.js
@@ -1,0 +1,28 @@
+import React from "react";
+
+class About extends React.Component {
+  render() {
+    return (
+      <div>
+        {/* the issues and source links will live in the header*/}
+        <a href="https://github.com/FormidableLabs/component-playground">Source Code on GitHub</a>
+        <br/>
+        <a href="https://github.com/FormidableLabs/component-playground/issues">Report an Issue</a>
+        <h1>About Component Playground</h1>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=watch&count=true&size=large&v=2" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=fork&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&type=follow&count=true&size=large" frameBorder="0" scrolling="0" width="220px" height="30px"></iframe>
+        <p>Component Playground is a React component that renders editable source code and a live preview of
+         other React components. It's great for showing off your code, tutorials, and walkthroughs.</p>
+        <p>Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript
+         using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some
+          of the world's biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.</p>
+        <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors</a>
+      {/*add top 5 contributors if we can figure out a good way with the github API*/}
+      </div>
+    );
+  }
+}
+
+export default About;

--- a/src/screens/about/index.js
+++ b/src/screens/about/index.js
@@ -4,22 +4,18 @@ class About extends React.Component {
   render() {
     return (
       <div>
-        {/* the issues and source links will live in the header*/}
-        <a href="https://github.com/FormidableLabs/component-playground">Source Code on GitHub</a>
-        <br/>
-        <a href="https://github.com/FormidableLabs/component-playground/issues">Report an Issue</a>
         <h1>About Component Playground</h1>
         <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
         <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=watch&count=true&size=large&v=2" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
         <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=fork&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px"></iframe>
         <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&type=follow&count=true&size=large" frameBorder="0" scrolling="0" width="220px" height="30px"></iframe>
         <p>Component Playground is a React component that renders editable source code and a live preview of
-         other React components. It's great for showing off your code, tutorials, and walkthroughs.</p>
+         other React components. It&#8217;s great for showing off your code, tutorials, and walkthroughs.</p>
+        <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors</a>
+        {/*add top 5 contributors if we can figure out a good way with the github API*/}
         <p>Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript
          using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some
-          of the world's biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.</p>
-        <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors</a>
-      {/*add top 5 contributors if we can figure out a good way with the github API*/}
+          of the world&#8217;s biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.</p>
       </div>
     );
   }

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,0 +1,18 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Ecology from "ecology";
+import GettingStarted from "../../../node_modules/component-playground/docs/getting-started.md";
+
+class Guide extends React.Component {
+  render() {
+    return (
+      <Ecology
+        overview={GettingStarted}
+        scope={{React, ReactDOM}}
+        playgroundtheme="elegant"
+      />
+    );
+  }
+}
+
+export default Guide;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
 import GettingStarted from "../../../node_modules/component-playground/docs/getting-started.md";
+import Api from "../../../node_modules/component-playground/docs/api.md";
 
 class Guide extends React.Component {
   render() {
@@ -15,4 +16,16 @@ class Guide extends React.Component {
   }
 }
 
-export default Guide;
+class Docs extends React.Component {
+  render() {
+    return (
+      <Ecology
+        overview={Api}
+        scope={{React, ReactDOM}}
+        playgroundtheme="elegant"
+      />
+    );
+  }
+}
+
+export { Guide, Docs };

--- a/src/screens/home/examples/componentExample.md
+++ b/src/screens/home/examples/componentExample.md
@@ -1,0 +1,92 @@
+```playground_norender
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      transitionData: this.getTransitionData(),
+      colorScale: [
+        "#D85F49",
+        "#F66D3B",
+        "#D92E1D",
+        "#D73C4C",
+        "#FFAF59",
+        "#E28300",
+        "#F6A57F"
+      ],
+      sliceWidth: 60,
+      style: {
+        parent: {
+          backgroundColor: "#f7f7f7",
+          border: "1px solid #ccc",
+          margin: "2%",
+          maxWidth: "40%"
+        }
+      }
+    };
+  }
+
+  componentDidMount() {
+    this.setStateInterval = window.setInterval(() => {
+      this.setState({
+        transitionData: this.getTransitionData()
+      });
+    }, 2000);
+  }
+
+  getTransitionData() {
+    const data = random(6, 9);
+    return range(data).map((datum) => {
+      return {
+        x: datum,
+        y: random(2, 9),
+        label: `#${datum}`
+      };
+    });
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.setStateInterval);
+  }
+
+  render() {
+    const containerStyle = {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      justifyContent: "center"
+    };
+
+    const parentStyle = {
+      backgroundColor: "#f7f7f7",
+      border: "1px solid #ccc",
+      margin: "2%",
+      maxWidth: "40%"
+    };
+
+    return (
+      <div>
+        <VictoryPie animate={{duration: 1000}}
+          style={{
+            parent: parentStyle,
+            labels: {
+              fontSize: 10,
+              padding: 100,
+              paintOrder: "stroke",
+              stroke: "#ffffff",
+              strokeWidth: 3,
+              strokeLinecap: "butt",
+              strokeLinejoin: "miter"
+            }
+          }}
+          data={this.state.transitionData}
+        />
+        <p>Powered by Victory</p>
+      </div>
+    )
+  }
+  
+}
+
+ReactDOM.render(<App/>, mountNode)
+```

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -1,19 +1,38 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Ecology from "ecology";
-import ComponentPlaygroundDocs from "../../../node_modules/component-playground/README.md";
+import { VictoryPie } from "victory";
+import { random, range } from "lodash";
+import Radium from "radium";
+import { Link } from "react-router";
+const RadiumLink = Radium(Link);
+
+const componentExample = require("!!raw!./examples/componentExample.md");
 
 class Home extends React.Component {
   render() {
     return (
-    <Ecology
-      overview={ComponentPlaygroundDocs}
-      scope={{
-        React, ReactDOM
-      }}
-      playgroundtheme="elegant"
-    />
-  );
+      <div>
+        <h1>Component Playground</h1>
+        <p>Render React.js components with editable source and live preview</p>
+        <pre><code>npm install component-playground</code></pre>
+        <Ecology
+          overview={componentExample}
+          scope={{React, VictoryPie, ReactDOM, random, range}}
+          playgroundtheme="elegant"
+        />
+        <a href="https://github.com/FormidableLabs/component-playground">Source Code on GitHub</a>
+        <br/>
+        <a href="https://github.com/FormidableLabs/component-playground/issues">Report an Issue</a>
+        <h2>Features</h2>
+          <ul>
+            <li>Allow editing of source code to illustrate changes</li>
+            <li>Live preview of React components</li>
+            <li>Great for tutorials and walkthroughs</li>
+          </ul>
+        <RadiumLink to="/docs/getting-started">Let's Get Started</RadiumLink>
+      </div>
+    );
   }
 }
 

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -13,9 +13,6 @@ class Home extends React.Component {
   render() {
     return (
       <div>
-        {/*The about and docs links will live in the header once added*/}
-        <RadiumLink to="/about">About</RadiumLink>
-        <RadiumLink to="/docs">Docs</RadiumLink>
         <h1>Component Playground</h1>
         <p>Render React.js components with editable source and live preview</p>
         <pre><code>npm install component-playground</code></pre>
@@ -34,7 +31,7 @@ class Home extends React.Component {
             <li>Live preview of React components</li>
             <li>Great for tutorials and walkthroughs</li>
           </ul>
-        <RadiumLink to="/docs/getting-started">Let's Get Started</RadiumLink>
+        <RadiumLink to="/docs/getting-started">Let&#8217;s Get Started</RadiumLink>
       </div>
     );
   }

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -13,9 +13,13 @@ class Home extends React.Component {
   render() {
     return (
       <div>
+        {/*The about and docs links will live in the header once added*/}
+        <RadiumLink to="/about">About</RadiumLink>
+        <RadiumLink to="/docs">Docs</RadiumLink>
         <h1>Component Playground</h1>
         <p>Render React.js components with editable source and live preview</p>
         <pre><code>npm install component-playground</code></pre>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
         <Ecology
           overview={componentExample}
           scope={{React, VictoryPie, ReactDOM, random, range}}

--- a/static-routes.js
+++ b/static-routes.js
@@ -3,5 +3,6 @@
 module.exports = [
   "/",
   "/docs",
-  "/docs/getting-started"
+  "/docs/getting-started",
+  "/about"
 ];

--- a/static-routes.js
+++ b/static-routes.js
@@ -1,5 +1,7 @@
 "use strict";
 
 module.exports = [
-	"/"
+  "/",
+  "/docs",
+  "/docs/getting-started"
 ];


### PR DESCRIPTION
this PR addresses https://github.com/FormidableLabs/formidable-landers/issues/141

This sets up the component playground docs to use the content components that we will hopefully be migrating all open source docs over to in order to maintain a consistent layout across projects and (hopefully) increase brand recognition. 

The three main components and their subcomponents are as follows:
Header (links to home, home for project, docs, issues or gitter, source, about)
1) Home. Title, tagline, "npm install" link to getting started guide, at least one example, feature list, star button, link to source, link to issues.
2) Docs. Should have sidebar with links to API, getting started guide, contributing instructions.
3) About. Blurbs about project/company, github buttons, link to contributor page on github.
Footer

/cc @paulathevalley 
