### PR TITLE
Add table of contents to sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-docgen": "2.7.0"
   },
   "dependencies": {
+    "anchorate": "^1.1.0",
     "babel-preset-stage-1": "^6.5.0",
     "builder": "^2.9.1",
     "builder-docs-archetype": "^4.1.1",

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -4,6 +4,7 @@ import { renderToString } from "react-dom/server";
 import { Router, RouterContext, match, applyRouterMiddleware, useRouterHistory } from "react-router";
 import { createMemoryHistory, createHistory } from "history";
 import useScroll from "react-router-scroll";
+import { anchorate } from "anchorate";
 import { renderAsHTML } from "./title-meta";
 import ReactGA from "react-ga";
 
@@ -30,6 +31,7 @@ if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //esl
     const fullLocation = basename + location.pathname;
     ReactGA.set({ page: fullLocation });
     ReactGA.pageview(fullLocation);
+    anchorate();
   });
   render(
     <Router

--- a/src/components/page.js
+++ b/src/components/page.js
@@ -12,7 +12,10 @@ class Page extends React.Component {
         <div className="Grid">
           <section className="Page">
             <div className="Page-sidebar Grid-col">
-              <Sidebar />
+              <Sidebar
+                tocArray={this.props.tocArray}
+                location={this.props.location}
+              />
             </div>
             <div className={`${contentClasses} Grid-col`}>
               { this.props.children }
@@ -26,12 +29,15 @@ class Page extends React.Component {
 
 Page.propTypes = {
   children: React.PropTypes.node,
-  home: React.PropTypes.bool
+  home: React.PropTypes.bool,
+  tocArray: React.PropTypes.array,
+  location: React.PropTypes.object
 };
 
 Page.defaultProps = {
   children: null,
-  home: false
+  home: false,
+  tocArray: []
 };
 
 

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import Icon from "./icon";
 import basename from "../basename";
 import MarkdownIt from "markdown-it";
+import { times } from "lodash";
 
 class Sidebar extends React.Component {
   renderTransformedToc(siblings, targetLocation) {
@@ -31,11 +32,12 @@ class Sidebar extends React.Component {
     );
   }
 
-  pushToDeeperLevel(siblings, levels, heading) {
+  pushToLevel(siblings, level, heading) {
+    siblings = siblings.slice(0);
     let parentTarget = siblings;
     let target;
 
-    while (levels-- > 0) {
+    times(level, () => {
       target = parentTarget[parentTarget.length - 1];
 
       if (Array.isArray(target)) {
@@ -44,29 +46,25 @@ class Sidebar extends React.Component {
         parentTarget.push([]);
         parentTarget = parentTarget[parentTarget.length - 1];
       }
-    }
+    });
 
     if (Array.isArray(target)) {
       target.push(heading);
     } else {
       parentTarget.push(heading);
     }
+
+    return siblings;
   }
 
   transformTocArray(headings) {
-    const siblings = [];
+    let siblings = [];
     const topHeading = headings[0];
 
-    for (let index = 0; index < headings.length; index++) {
-      const heading = headings[index];
-      const levelDiff = heading.level - topHeading.level;
-
-      if (levelDiff === 0) {
-        siblings.push(heading);
-      } else if (levelDiff > 0) {
-        this.pushToDeeperLevel(siblings, levelDiff, heading);
-      }
-    }
+    headings.forEach((heading) => {
+      const level = heading.level - topHeading.level;
+      siblings = this.pushToLevel(siblings, level, heading);
+    });
 
     return siblings;
   }

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -58,15 +58,12 @@ class Sidebar extends React.Component {
   }
 
   transformTocArray(headings) {
-    let siblings = [];
     const topHeading = headings[0];
 
-    headings.forEach((heading) => {
+    return headings.reduce((siblings, heading) => {
       const level = heading.level - topHeading.level;
-      siblings = this.pushToLevel(siblings, level, heading);
-    });
-
-    return siblings;
+      return this.pushToLevel(siblings, level, heading);
+    }, []);
   }
 
   renderToc(targetLocation) {

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,8 +1,32 @@
 import React from "react";
 import { Link } from "react-router";
 import Icon from "./icon";
+import { forEach } from "lodash";
+import basename from "../basename";
 
 class Sidebar extends React.Component {
+  renderToc(targetLocation) {
+    if (!this.props.location || (this.props.location.pathname !== targetLocation)) {
+      return null;
+    }
+
+    const list = this.props.tocArray.filter(({level}) => level > 1);
+
+    return (
+      <ul>
+        {
+          list.map((thing, id) => (
+            <li key={id}>
+              <a href={`${basename}${targetLocation}#${thing.anchor}`}>
+                {thing.content}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    );
+  }
+
   render() {
     return (
       <nav className="Nav">
@@ -16,6 +40,7 @@ class Sidebar extends React.Component {
                 Let’s Get Started <Icon />
               </span>
             </Link>
+            {this.renderToc("/docs/getting-started")}
           </li>
           <li className="NavList-item">
             <Link to="/docs" className="btn btn--dark" activeClassName="is-active">
@@ -23,6 +48,7 @@ class Sidebar extends React.Component {
                 API <Icon />
               </span>
             </Link>
+            {this.renderToc("/docs")}
           </li>
           <li className="NavList-item">
             <Link to="/about" className="btn btn--dark" activeClassName="is-active">
@@ -36,5 +62,10 @@ class Sidebar extends React.Component {
     );
   }
 }
+
+Sidebar.propTypes = {
+  location: React.PropTypes.object,
+  tocArray: React.PropTypes.array
+};
 
 export default Sidebar;

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -1,0 +1,113 @@
+import React from "react";
+import find from "lodash/find";
+
+import MarkdownIt from "markdown-it";
+import markdownItTocAndAnchor from "markdown-it-toc-and-anchor";
+import Prism from "prismjs";
+/* eslint-disable no-unused-vars */
+// add more language support
+import jsx from "prismjs/components/prism-jsx";
+import sh from "prismjs/components/prism-bash";
+import yaml from "prismjs/components/prism-yaml";
+/* eslint-enable no-unused-vars */
+
+import basename from "../../../basename";
+import { config } from "../../../components/config";
+
+
+class Markdown extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      renderedMd: ""
+    };
+  }
+
+  componentDidMount() {
+    Prism.highlightAll();
+  }
+
+  componentDidUpdate() { // is this the right one??
+    Prism.highlightAll();
+  }
+
+  componentWillMount() {
+    this.renderMd(this.props);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.location.pathname !== this.props.location.pathname) {
+      this.renderMd(newProps);
+    }
+  }
+
+  renderMd(props) {
+    this.setMarkdownRenderer(props.location.pathname);
+    const activePage = props.params.component ?
+      props.params.component : "index";
+    const docsMarkdown = find(config, { slug: activePage }).docs;
+    this.setState({
+      renderedMd: this.md.render(docsMarkdown)
+    });
+  }
+
+  /* eslint-disable camelcase, max-params */
+  // Create a markdown renderer that builds relative links
+  // based on the currentPath and site's base href
+  setMarkdownRenderer(currentPath) {
+    const md = new MarkdownIt({
+      html: true,
+      linkify: true,
+      typographer: true
+    });
+
+    md.use(markdownItTocAndAnchor, {
+      anchorLinkSymbol: "",
+      anchorClassName: "Anchor",
+      tocCallback: (tocMarkdown, tocArray) => {
+        this.props.updateTocArray(tocArray);
+      }
+    });
+
+    // store the original rule
+    const defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, renderer) {
+      return renderer.renderToken(tokens, idx, options);
+    };
+    //
+    // Update anchor links to include the basename
+    md.renderer.rules.link_open = function (tokens, idx, options, env, renderer) {
+      const anchor = tokens[idx].attrs[1];
+      if (anchor.length > 0) {
+        const href = anchor[1];
+        if (href.indexOf("#") === 0) {
+          tokens[idx].attrs[1][1] = `${basename}${currentPath}${href}`;
+        }
+      }
+      return defaultRender(tokens, idx, options, env, renderer);
+    };
+
+    this.md = md;
+  }
+
+  render() {
+    return (
+      <article
+        dangerouslySetInnerHTML={{
+          __html: this.state.renderedMd
+        }}
+      />
+    );
+  }
+}
+
+Markdown.propTypes = {
+  location: React.PropTypes.object.isRequired,
+  params: React.PropTypes.object,
+  updateTocArray: React.PropTypes.func.isRequired
+};
+
+Markdown.defaultProps = {
+  params: null
+};
+
+export default Markdown;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,90 +1,33 @@
 import React from "react";
-import find from "lodash/find";
-
-import MarkdownIt from "markdown-it";
-import markdownItTocAndAnchor from "markdown-it-toc-and-anchor";
-import Prism from "prismjs";
-/* eslint-disable no-unused-vars */
-// add more language support
-import jsx from "prismjs/components/prism-jsx";
-import sh from "prismjs/components/prism-bash";
-import yaml from "prismjs/components/prism-yaml";
-/* eslint-enable no-unused-vars */
 
 import Page from "../../components/page";
-import basename from "../../basename";
-import { config } from "../../components/config";
+import Markdown from "./components/markdown";
 
 
 class Docs extends React.Component {
-  componentDidMount() {
-    Prism.highlightAll();
-  }
+  constructor() {
+    super();
 
-  componentDidUpdate() { // is this the right one??
-    Prism.highlightAll();
-  }
-
-  componentWillMount() {
-    this.setMarkdownRenderer(this.props.location.pathname);
-  }
-
-  /* eslint-disable camelcase, max-params */
-  // Create a markdown renderer that builds relative links
-  // based on the currentPath and site's base href
-  setMarkdownRenderer(currentPath) {
-    const md = new MarkdownIt({
-      html: true,
-      linkify: true,
-      typographer: true
-    });
-
-    md.use(markdownItTocAndAnchor, {
-      anchorLinkSymbol: "",
-      anchorClassName: "Anchor",
-      tocCallback(tocMarkdown, tocArray) {
-        // TODO: Pass toc to <Page /> component
-        console.log(tocArray); // eslint-disable-line no-console
-      }
-    });
-
-    // store the original rule
-    const defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, renderer) {
-      return renderer.renderToken(tokens, idx, options);
+    this.state = {
+      tocArray: []
     };
-    //
-    // Update anchor links to include the basename
-    md.renderer.rules.link_open = function (tokens, idx, options, env, renderer) {
-      const anchor = tokens[idx].attrs[1];
-      if (anchor.length > 0) {
-        const href = anchor[1];
-        if (href.indexOf("#") === 0) {
-          tokens[idx].attrs[1][1] = `${basename}${currentPath}${href}`;
-        }
-      }
-      return defaultRender(tokens, idx, options, env, renderer);
-    };
-
-    this.md = md;
   }
 
-  renderDocs(active) {
-    const docsMarkdown = find(config, { slug: active }).docs;
-    return (
-      <article
-        dangerouslySetInnerHTML={{
-          __html: this.md.render(docsMarkdown)
-        }}
-      />
-    );
+  updateTocArray(tocArray) {
+    this.setState({tocArray});
   }
 
   render() {
-    const activePage = this.props.params.component ?
-      this.props.params.component : "index";
     return (
-      <Page>
-        { this.renderDocs(activePage) }
+      <Page
+        tocArray={this.state.tocArray}
+        location={this.props.location}
+      >
+        <Markdown
+          location={this.props.location}
+          params={this.props.params}
+          updateTocArray={this.updateTocArray.bind(this)}
+        />
       </Page>
     );
   }


### PR DESCRIPTION
Addresses #9 

This is a work in progress.  I'm still working on a way to generate nested `<ul>`s from the `tocArray` that is generated by `markdown-it-toc-and-anchor`.

It currently looks like:
![image](https://cloud.githubusercontent.com/assets/13814048/18887123/b4a31f4c-84a7-11e6-919f-cabb49cad01d.png)
