### PR TITLE
Run aXe audit

### DIFF
--- a/src/screens/about/index.js
+++ b/src/screens/about/index.js
@@ -1,39 +1,42 @@
 import React from "react";
 import Page from "../../components/page";
+import TitleMeta from "../../components/title-meta";
 
 class About extends React.Component {
   render() {
     return (
-      <Page>
-        <h1 className="u-noMarginTop">
-          About
-        </h1>
-        <p>
-        {/*
-          TODO: Custom GitHub Buttons https://github.com/FormidableLabs/formidable-landers/issues/175
+      <TitleMeta title="Component Playground | About">
+        <Page>
+          <h1 className="u-noMarginTop">
+            About
+          </h1>
+          <p>
+          {/*
+            TODO: Custom GitHub Buttons https://github.com/FormidableLabs/formidable-landers/issues/175
+          */}
+            <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px" title="Stars on GitHub"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=watch&count=true&size=large&v=2" frameBorder="0" scrolling="0" width="160px" height="30px" title="Watch on GitHub"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=fork&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px" title="Fork on GitHub"></iframe>
+          </p>
+          <p>
+            Component Playground is a React component that renders editable source code and a live preview of other React components. It&#8217;s great for showing off your code, and for leveling up tutorials and walkthroughs.
+         </p>
+         <p>
+         {/*
+           TODO: Add Top 5 Contributors through the GitHub API
+           https://github.com/FormidableLabs/formidable-landers/issues/176
         */}
-          <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px" title="Stars on GitHub"></iframe>
-          <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=watch&count=true&size=large&v=2" frameBorder="0" scrolling="0" width="160px" height="30px" title="Watch on GitHub"></iframe>
-          <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=fork&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px" title="Fork on GitHub"></iframe>
+          <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors to Component Playground.</a>
         </p>
         <p>
-          Component Playground is a React component that renders editable source code and a live preview of other React components. It&#8217;s great for showing off your code, and for leveling up tutorials and walkthroughs.
-       </p>
-       <p>
-       {/*
-         TODO: Add Top 5 Contributors through the GitHub API
-         https://github.com/FormidableLabs/formidable-landers/issues/176
-      */}
-        <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors to Component Playground.</a>
-      </p>
-      <p>
-      {/*
-        TODO: Extract Formidable blurb into formidable-landers
-        https://github.com/FormidableLabs/formidable-landers/issues/177
-      */}
-        Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some of the world&#8217;s biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.
-      </p>
-    </Page>
+        {/*
+          TODO: Extract Formidable blurb into formidable-landers
+          https://github.com/FormidableLabs/formidable-landers/issues/177
+        */}
+          Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some of the world&#8217;s biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.
+        </p>
+      </Page>
+    </TitleMeta>
     );
   }
 }

--- a/src/screens/about/index.js
+++ b/src/screens/about/index.js
@@ -20,23 +20,23 @@ class About extends React.Component {
           </p>
           <p>
             Component Playground is a React component that renders editable source code and a live preview of other React components. It&#8217;s great for showing off your code, and for leveling up tutorials and walkthroughs.
-         </p>
-         <p>
-         {/*
-           TODO: Add Top 5 Contributors through the GitHub API
-           https://github.com/FormidableLabs/formidable-landers/issues/176
-        */}
-          <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors to Component Playground.</a>
-        </p>
-        <p>
-        {/*
-          TODO: Extract Formidable blurb into formidable-landers
-          https://github.com/FormidableLabs/formidable-landers/issues/177
-        */}
-          Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some of the world&#8217;s biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.
-        </p>
-      </Page>
-    </TitleMeta>
+          </p>
+          <p>
+            {/*
+              TODO: Add Top 5 Contributors through the GitHub API
+              https://github.com/FormidableLabs/formidable-landers/issues/176
+           */}
+            <a href="https://github.com/FormidableLabs/component-playground/graphs/contributors">See Contributors to Component Playground.</a>
+          </p>
+          <p>
+          {/*
+            TODO: Extract Formidable blurb into formidable-landers
+            https://github.com/FormidableLabs/formidable-landers/issues/177
+          */}
+            Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some of the world&#8217;s biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.
+          </p>
+        </Page>
+      </TitleMeta>
     );
   }
 }

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -62,7 +62,8 @@ class Markdown extends React.Component {
     });
 
     md.use(markdownItTocAndAnchor, {
-      anchorLinkSymbol: "",
+      anchorLinkSymbol: "heading anchor link",
+      anchorLinkSymbolClassName: "visually-hidden",
       anchorClassName: "Anchor",
       tocCallback: (tocMarkdown, tocArray) => {
         this.props.updateTocArray(tocArray);

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -62,8 +62,7 @@ class Markdown extends React.Component {
     });
 
     md.use(markdownItTocAndAnchor, {
-      anchorLinkSymbol: "heading anchor link",
-      anchorLinkSymbolClassName: "visually-hidden",
+      anchorLinkSymbol: "",
       anchorClassName: "Anchor",
       tocCallback: (tocMarkdown, tocArray) => {
         this.props.updateTocArray(tocArray);

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Page from "../../components/page";
+import TitleMeta from "../../components/title-meta";
 import Markdown from "./components/markdown";
 
 
@@ -19,16 +20,18 @@ class Docs extends React.Component {
 
   render() {
     return (
-      <Page
-        tocArray={this.state.tocArray}
-        location={this.props.location}
-      >
-        <Markdown
+      <TitleMeta title="Component Playground | Documentation">
+        <Page
+          tocArray={this.state.tocArray}
           location={this.props.location}
-          params={this.props.params}
-          updateTocArray={this.updateTocArray.bind(this)}
-        />
-      </Page>
+        >
+          <Markdown
+            location={this.props.location}
+            params={this.props.params}
+            updateTocArray={this.updateTocArray.bind(this)}
+          />
+        </Page>
+      </TitleMeta>
     );
   }
 }

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -5,57 +5,60 @@ import { VictoryPie } from "victory";
 import { random, range } from "lodash";
 
 import Page from "../../components/page";
+import TitleMeta from "../../components/title-meta";
 const componentExample = require("!!raw!./examples/component.example");
 
 class Home extends React.Component {
   render() {
     return (
-      <main className="Main">
-        <div className="Hero Grid">
-          <h2 className="Hero-heading">
-            Render React.js components with editable source & live preview
-          </h2>
-          <hr className="Hero-hr hr" />
-          <div className="Hero-installer">
-            <code>npm install component-playground</code>
-            <p className="u-textCenter">
-              <iframe title="Stars on GitHub" src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true" frameBorder="0" scrolling="0" width="90px" height="20px"></iframe>
-            </p>
+      <TitleMeta title="Component Playground">
+        <main className="Main">
+          <div className="Hero Grid">
+            <h2 className="Hero-heading">
+              Render React.js components with editable source & live preview
+            </h2>
+            <hr className="Hero-hr hr" />
+            <div className="Hero-installer">
+              <code>npm install component-playground</code>
+              <p className="u-textCenter">
+                <iframe title="Stars on GitHub" src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=component-playground&type=star&count=true" frameBorder="0" scrolling="0" width="90px" height="20px"></iframe>
+              </p>
+            </div>
+            <div className="Hero-example Grid-col">
+              <Playground
+                codeText={componentExample}
+                scope={{ React, VictoryPie, ReactDOM, random, range }}
+                noRender={false}
+                theme="elegant"
+              />
+            </div>
           </div>
-          <div className="Hero-example Grid-col">
-            <Playground
-              codeText={componentExample}
-              scope={{ React, VictoryPie, ReactDOM, random, range }}
-              noRender={false}
-              theme="elegant"
-            />
-          </div>
-        </div>
 
-        <Page home>
-          <h3 className="u-noMarginTop">
-            Features
-          </h3>
-          <h4 className="u-marginTopSmall">
-            Allow editing of source code to illustrate changes
-          </h4>
-          <p>
-            We’ve used Component Playground to allow people to edit themes and see the changes in real time. Let people see how flexible your software is for themselves.
-          </p>
-          <h4>
-            Live preview of React components
-          </h4>
-          <p>
-            Upgrade from a gif and show people what’s behind-the-scenes on that cool animated component.
-          </p>
-          <h4>
-            Great for tutorials and walkthroughs
-          </h4>
-          <p>
-            Help users keep track of what’s going on at any given point in a guide or tutorial with live code.
-          </p>
-        </Page>
-      </main>
+          <Page home>
+            <h3 className="u-noMarginTop">
+              Features
+            </h3>
+            <h4 className="u-marginTopSmall">
+              Allow editing of source code to illustrate changes
+            </h4>
+            <p>
+              We’ve used Component Playground to allow people to edit themes and see the changes in real time. Let people see how flexible your software is for themselves.
+            </p>
+            <h4>
+              Live preview of React components
+            </h4>
+            <p>
+              Upgrade from a gif and show people what’s behind-the-scenes on that cool animated component.
+            </p>
+            <h4>
+              Great for tutorials and walkthroughs
+            </h4>
+            <p>
+              Help users keep track of what’s going on at any given point in a guide or tutorial with live code.
+            </p>
+          </Page>
+        </main>
+      </TitleMeta>
     );
   }
 }

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -70,3 +70,14 @@
   opacity: 0;
   width: 30px;
 }
+
+.visually-hidden { /*https://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html*/
+    position: absolute !important;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    padding:0 !important;
+    border:0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
+}

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -70,14 +70,3 @@
   opacity: 0;
   width: 30px;
 }
-
-.visually-hidden { /*https://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html*/
-    position: absolute !important;
-    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-    clip: rect(1px, 1px, 1px, 1px);
-    padding:0 !important;
-    border:0 !important;
-    height: 1px !important;
-    width: 1px !important;
-    overflow: hidden;
-}

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -61,7 +61,6 @@
 
 .Anchor {
   background: url("../../static/icon-link.svg") center left no-repeat;
-  /*float: left;*/
   position: absolute;
   left: -30px;
 
@@ -69,4 +68,5 @@
   line-height: 1;
   opacity: 0;
   width: 30px;
+  speak: none; /* Wishing for .screenreader-hidden class */
 }

--- a/src/styles/components/prism.css
+++ b/src/styles/components/prism.css
@@ -30,13 +30,13 @@ pre[class*="language-"] {
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
   text-shadow: none;
-  background: #b3d4fc;
+  background: var(--codeMirrorbgFocused);
 }
 
 pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
 code[class*="language-"]::selection, code[class*="language-"] ::selection {
   text-shadow: none;
-  background: #b3d4fc;
+  background: var(--codeMirrorbgFocused);
 }
 
 @media print {
@@ -53,7 +53,7 @@ pre[class*="language-"] {
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-  background: #f5f2f0;
+  background: var(--codeMirrorbg);
 }
 
 /* Inline code */
@@ -67,11 +67,11 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #586e75;
+  color: var(--codeMirrorComment);
 }
 
 .token.punctuation {
-  color: #999;
+  color: var(--codeMirrorPunctuation);
 }
 
 .namespace {
@@ -85,7 +85,7 @@ pre[class*="language-"] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #905;
+  color: var(--codeMirrorNumber);
 }
 
 .token.selector,
@@ -94,7 +94,7 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #2aa198
+  color: var(--codeMirrorSelector)
 }
 
 .token.operator,
@@ -102,24 +102,24 @@ pre[class*="language-"] {
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #a67f59;
+  color: var(--codeMirrorOperator);
   background: hsla(0, 0%, 100%, .5);
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #268bd2;
+  color: var(--codeMirrorKeyword);
 }
 
 .token.function {
-  color: #DD4A68;
+  color: var(--codeMirrorFunction);
 }
 
 .token.regex,
 .token.important,
 .token.variable {
-  color: #e90;
+  color: var(--codeMirrorVariable);
 }
 
 .token.important,


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/component-playground-docs/issues/12 
- Add missing `<title>` elements using the `<TitleMeta>` component
- Update `prism.css` with syntax highlighting colors with proper color contrast ratios

The remaining issues are out of the dox control: 
- a missing `lang` attribute on `<html>` in the github buttons’ `iframe`
- a missing label on the Playground’s `textarea` element
- anchor links do not have discernible text (since we are using `markdown-it-toc-and-anchor` we do not have control over the markup... not sure if there’s a workaround using just CSS)

/cc @rawrmonstar 
