### PR TITLE
Manually adjust text size for narrow screens

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -8,9 +8,11 @@ import "../styles/styles.css";
 class App extends React.Component {
   render() {
     const Title = (
-      <Link to="/" className="Heading">
-        Component Playground
-      </Link>
+      <h1 className="Heading">
+        <Link to="/">
+          Component Playground
+        </Link>
+      </h1>
     );
 
     return (

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -20,7 +20,7 @@ class App extends React.Component {
         <Header
           logoProject={Title}
           theme="light"
-          padding="60px 2%"
+          padding="3.75rem 2%"
           style={{
             background: "transparent"
           }}

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -1,6 +1,11 @@
 html {
   background-color: var(--black);
   box-sizing: border-box;
+  font-size: 14px;
+
+  @media (--medium-viewport) {
+    font-size: 16px;
+  }
 }
 
 *, *:before, *:after {
@@ -11,13 +16,8 @@ body {
   background-color: var(--lightestGray);
   color: var(--black);
   font-family: var(--fontMonospace);
-  font-size: 14px;
   line-height: 1.75;
   position: relative;
-
-  @media (--medium-viewport) {
-    font-size: 16px;
-  }
 }
 
 /*
@@ -123,11 +123,7 @@ h6 {
 }
 
 h1 {
-  font-size: 3rem;
-
-  @media (--medium-viewport) {
-    font-size: 3.75rem; /* 60px */
-  }
+  font-size: 3.75rem;
 }
 
 h2 {
@@ -136,9 +132,8 @@ h2 {
   text-transform: uppercase;
 
   @media (--medium-viewport) {
-    font-size: 3rem; /* 48px */
+    font-size: 3rem;
   }
-
 }
 
 h3 {

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -123,13 +123,22 @@ h6 {
 }
 
 h1 {
-  font-size: 3.75rem; /* 60px */
+  font-size: 3rem;
+
+  @media (--medium-viewport) {
+    font-size: 3.75rem; /* 60px */
+  }
 }
 
 h2 {
-  font-size: 3rem; /* 48px */
+  font-size: 2rem;
   letter-spacing: 0.175em;
   text-transform: uppercase;
+
+  @media (--medium-viewport) {
+    font-size: 3rem; /* 48px */
+  }
+
 }
 
 h3 {

--- a/src/styles/base/text.css
+++ b/src/styles/base/text.css
@@ -1,8 +1,6 @@
 .Heading {
   font-family: var(--fontHeading);
-  font-size: 60px;
   font-weight: normal;
   line-height: 1.2;
   margin: 0;
-  text-indent: -20px;
 }

--- a/src/styles/components/hero.css
+++ b/src/styles/components/hero.css
@@ -26,6 +26,7 @@
 .Hero-installer code {
   border: 0;
   font-size: inherit;
+  padding: 0;
 }
 
 .Hero-example {

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -4,9 +4,13 @@
 
 .Page-content p {
   font-family: var(--fontBody);
-  font-size: 1.125rem;
+  font-size: 1rem;
   line-height: 1.7;
   max-width: 36em;
+
+  @media (--medium-viewport) {
+    font-size: 1.125rem;
+  }
 }
 
 /*
@@ -37,7 +41,10 @@
   font-family: var(--fontHeading);
   font-size: 1.5rem;
   margin-top: var(--gutter);
-  margin-bottom: -1.375rem;
+
+  @media (--medium-viewport) {
+    margin-bottom: -1.375rem;
+  }
 }
 
 /* Style the markdown links */

--- a/src/styles/components/page.css
+++ b/src/styles/components/page.css
@@ -4,13 +4,9 @@
 
 .Page-content p {
   font-family: var(--fontBody);
-  font-size: 1rem;
+  font-size: 1.125rem;
   line-height: 1.7;
   max-width: 36em;
-
-  @media (--medium-viewport) {
-    font-size: 1.125rem;
-  }
 }
 
 /*
@@ -41,10 +37,7 @@
   font-family: var(--fontHeading);
   font-size: 1.5rem;
   margin-top: var(--gutter);
-
-  @media (--medium-viewport) {
-    margin-bottom: -1.375rem;
-  }
+  margin-bottom: -1rem;
 }
 
 /* Style the markdown links */


### PR DESCRIPTION
I must not fully understand `rem` sizing. I was hoping that changing the base pixel font size on `body` for each viewport would cascade down to all the `rem` sizes, but they are not adjusting in that way. 

This PR manually adjusts the large heading sizes and the paragraph elements for the internal pages. 

<img width="344" alt="screen shot 2016-09-30 at 3 33 42 pm" src="https://cloud.githubusercontent.com/assets/768965/19008874/4b4259fe-8723-11e6-842e-57259c0fe92b.png">

/cc @rawrmonstar @hamoore 
