### PR TITLE
Add aria-hidden='true' to heading anchor links

### DIFF
--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -81,6 +81,7 @@ class Markdown extends React.Component {
         const href = anchor[1];
         if (href.indexOf("#") === 0) {
           tokens[idx].attrs[1][1] = `${basename}${currentPath}${href}`;
+          tokens[idx].attrs.push(["aria-hidden", "true"]);
         }
       }
       return defaultRender(tokens, idx, options, env, renderer);


### PR DESCRIPTION
This resolves the accessibility issue of having empty links as the heading anchor links.  The same links are still accessible to screen-reader users via the sidebar.

/cc @paulathevalley 
